### PR TITLE
Fix crash if url is longer than 60 characters. Option to change inverter IP

### DIFF
--- a/src/SMAReader.h
+++ b/src/SMAReader.h
@@ -123,7 +123,7 @@ class SMAReader {
       */
      int getLog(uint32_t startTime, uint32_t endTime, uint32_t* values, uint32_t* timestamps=nullptr);
      bool getAllValues();
-     
+     void setInverterIP(IPAddress inverterAddress);
      
   private:
      IPAddress _inverterAddress;


### PR DESCRIPTION
Still amazed by your library. But after working for a long time, my app crashed the other day suddenly after I had to change the IP address of the inverter and flashed a new version with the new IP address.

Original the IP address was `192.168.1.86`, the new one is `192.168.1.172`. This made the URL 61 characters long in `getValuesAux`. As the URL string is created with `sprintf`, and the URL buffer was only 60 bytes large it caused an Stack error crash. I fixed it by extending the URL buffer to 128 bytes.

In addition, I implemented a function in my app to set the IP address manually when it changes. As the IP address was set static in the class declaration, I needed a function to change the IP without recompiling the code. I created the function `void SMAReader::setInverterIP(IPAddress inverterAddress)` that allows to change the IP address during runtime.